### PR TITLE
mvn clean package needs org.hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
     </properties>
 
     <dependencies>
+<dependency>
+    <groupId>org.hamcrest</groupId>
+    <artifactId>hamcrest-core</artifactId>
+    <version>1.3</version>
+</dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-core</artifactId>


### PR DESCRIPTION
I tried to do a "git clone" then "mvn clean package". It seems that it is not possible without including the dependency of org.hamcrest. Or else, please add instructions to ignore the dependency.